### PR TITLE
Load Filenames on Restart of Server / Add XML response for Delete_Objects.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -21,6 +21,8 @@ GEM
     mini_portile (0.6.1)
     nokogiri (1.6.4.1)
       mini_portile (~> 0.6.0)
+    nokogiri (1.6.4.1-x64-mingw32)
+      mini_portile (~> 0.6.0)
     rake (10.1.0)
     rest-client (1.6.7)
       mime-types (>= 1.16)
@@ -32,6 +34,7 @@ GEM
 
 PLATFORMS
   ruby
+  x64-mingw32
 
 DEPENDENCIES
   aws-s3

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,17 +16,12 @@ GEM
       json (~> 1.4)
       nokogiri (>= 1.4.4)
     builder (3.2.2)
-    byebug (4.0.1)
-      columnize (= 0.9.0)
-      rb-readline (= 0.5.2)
-    columnize (0.9.0)
     json (1.8.1)
     mime-types (1.25)
     mini_portile (0.6.1)
     nokogiri (1.6.4.1)
       mini_portile (~> 0.6.0)
     rake (10.1.0)
-    rb-readline (0.5.2)
     rest-client (1.6.7)
       mime-types (>= 1.16)
     right_aws (3.1.0)
@@ -42,8 +37,10 @@ DEPENDENCIES
   aws-s3
   aws-sdk-v1
   bundler (>= 1.0.0)
-  byebug
   fakes3!
   rake
   rest-client
   right_aws
+
+BUNDLED WITH
+   1.10.6

--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -26,6 +26,19 @@ module FakeS3
         bucket_obj = Bucket.new(bucket_name,Time.now,[])
         @buckets << bucket_obj
         @bucket_hash[bucket_name] = bucket_obj
+
+        #pre-load objects into bucket, so ListObjects calls work.
+        Dir[File.join(bucket,'/**/.fakes3_metadataFFF')].each do |fullpath|
+          key = fullpath.sub('/.fakes3_metadataFFF', '').sub(bucket + '/', '')
+          object = get_object(bucket_name, key, 'norequest')
+          bucket_obj.add(object)
+        end
+      end
+
+      puts "=================================================="
+      puts "Buckets initialized with contents:"
+      buckets.each do |b|
+        puts "#{b.name} - #{b.objects.count} items"
       end
     end
 

--- a/lib/fakes3/file_store.rb
+++ b/lib/fakes3/file_store.rb
@@ -32,6 +32,7 @@ module FakeS3
           key = fullpath.sub('/.fakes3_metadataFFF', '').sub(bucket + '/', '')
           object = get_object(bucket_name, key, 'norequest')
           bucket_obj.add(object)
+          object.io.close
         end
       end
 

--- a/lib/fakes3/sorted_object_list.rb
+++ b/lib/fakes3/sorted_object_list.rb
@@ -1,11 +1,12 @@
 require 'set'
 module FakeS3
   class S3MatchSet
-    attr_accessor :matches,:is_truncated,:common_prefixes
+    attr_accessor :matches,:is_truncated,:common_prefixes,:next_marker
     def initialize
       @matches = []
       @is_truncated = false
       @common_prefixes = []
+	  @next_marker = ""
     end
   end
 
@@ -102,7 +103,7 @@ module FakeS3
                   ms.common_prefixes << base_prefix + chunks[0] + delimiter
                   last_chunk = chunks[0]
                 else
-                  is_truncated = true
+                  ms.is_truncated = true
                   break
                 end
               end
@@ -117,7 +118,8 @@ module FakeS3
           if count <= max_keys
             ms.matches << s3_object
           else
-            is_truncated = true
+            ms.is_truncated = true
+			ms.next_marker = s3_object.name
             break
           end
         end

--- a/lib/fakes3/xml_adapter.rb
+++ b/lib/fakes3/xml_adapter.rb
@@ -218,5 +218,20 @@ module FakeS3
       }
       output
     end
+	
+	# <DeleteObjectsResult>
+    #   <LastModified>2009-10-28T22:32:00</LastModified>
+    #   <ETag>"9b2cf535f27731c974343645a3985328"</ETag>
+    # </CopyObjectResult>
+    def self.delete_objects_result(object)
+      output = ""
+      xml = Builder::XmlMarkup.new(:target => output)
+      xml.instruct! :xml, :version=>"1.0", :encoding=>"UTF-8"
+      xml.DeleteResult(:xmlns => "http://s3.amazonaws.com/doc/2006-03-01/") { |result|
+
+      }
+      output
+    end
+	
   end
 end

--- a/test/aws_sdk_commands_test.rb
+++ b/test/aws_sdk_commands_test.rb
@@ -10,6 +10,21 @@ class AwsSdkCommandsTest < Test::Unit::TestCase
                       :use_ssl => false)
   end
 
+  def test_list_objects
+    #assemble
+    bucket = @s3.buckets["test_list_objects"]
+    object = bucket.objects["key1"]
+    object.write("asdf")
+    object.copy_to("prefix1/sub1/key2")
+    object.copy_to("prefix1/sub2/key3")
+ 
+    #act & assert
+    assert_equal 3, bucket.objects.count
+    assert_equal 2, bucket.objects.with_prefix('prefix1/').count
+    assert_equal 1, bucket.objects.with_prefix('prefix1/sub2/').count
+    assert (not bucket.objects.with_prefix('prefix1/').collect(&:key).include? 'key1')
+  end
+
   def test_copy_to
     bucket = @s3.buckets["test_copy_to"]
     object = bucket.objects["key1"]


### PR DESCRIPTION
Restarting the Fake-S3 server causes it lose the keys of existing content.  This fix will reload the files into the Bucket data structure, so that server can be restarted without losing previously stored content.

Delete_Objects should return an XML response with <DeleteResponse> root tag.
